### PR TITLE
Fix missing React imports

### DIFF
--- a/src/app/Chat/page.tsx
+++ b/src/app/Chat/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import React from 'react';
+
 const Chat: React.FC = () => {
     return (
         <div className="w-full flex flex-col items-center text-white">

--- a/src/app/RootShell.tsx
+++ b/src/app/RootShell.tsx
@@ -2,6 +2,7 @@
 
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
+import type React from "react";
 import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBars } from "@fortawesome/free-solid-svg-icons";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // src/app/layout.tsx
 import type { Metadata } from "next";
+import type React from "react";
 import "./globals.css";
 import RootShell from "./RootShell";
 


### PR DESCRIPTION
## Summary
- add missing React import to Chat page
- import React types in main layout
- import React types in RootShell

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7a6a7010832b97d7493f8c8e759b