### PR TITLE
Add theme transitions

### DIFF
--- a/src/app/About/page.tsx
+++ b/src/app/About/page.tsx
@@ -21,7 +21,7 @@ const skills = [
 
 const SkillRadar = () => (
   <div className="flex flex-col items-center gap-6">
-    <div className="text-center text-lg font-semibold text-[#98BAD2]">技能分佈</div>
+  <div className="text-center text-lg font-semibold text-blue-700 dark:text-[#98BAD2]">技能分佈</div>
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
       {skills.map((skill, idx) => (
         <div key={idx} className="relative w-[180px] h-[180px] mx-auto sm:mx-0">
@@ -87,26 +87,26 @@ const certifications = [
 
 const Card = ({ title, children }: { title: string; children: React.ReactNode }) => (
   <motion.div
-    className="relative bg-[#1f1f28] rounded-2xl shadow-xl w-full px-6 sm:px-8 py-6 hover:scale-[1.02] transition-transform duration-300"
+    className="relative bg-white dark:bg-[#1f1f28] rounded-2xl shadow-xl w-full px-6 sm:px-8 py-6 hover:scale-[1.02] transition-transform duration-300"
     initial={{ opacity: 0, y: 30 }}
     whileInView={{ opacity: 1, y: 0 }}
     transition={{ duration: 0.6 }}
   >
     <div className="absolute top-6 left-0 w-1 h-12 bg-gradient-to-b from-purple-400 via-pink-400 to-yellow-400 rounded-r-full animate-pulse" />
-    <h3 className="text-2xl font-bold mb-2 text-[#98BAD2] pl-4">{title}</h3>
+    <h3 className="text-2xl font-bold mb-2 text-blue-700 dark:text-[#98BAD2] pl-4">{title}</h3>
     <div className="text-[#ccd6f6] text-base pl-4">{children}</div>
   </motion.div>
 );
 
 const Timeline = ({ title, data }: { title: string; data: Record<string, string[]> }) => (
   <motion.div
-    className="relative bg-[#1f1f28] rounded-2xl shadow-xl w-full px-6 sm:px-8 py-6 hover:scale-[1.02] transition-transform duration-300"
+    className="relative bg-white dark:bg-[#1f1f28] rounded-2xl shadow-xl w-full px-6 sm:px-8 py-6 hover:scale-[1.02] transition-transform duration-300"
     initial={{ opacity: 0, y: 30 }}
     whileInView={{ opacity: 1, y: 0 }}
     transition={{ duration: 0.6 }}
   >
     <div className="absolute top-6 left-0 w-1 h-12 bg-gradient-to-b from-blue-400 via-cyan-400 to-teal-400 rounded-r-full animate-pulse" />
-    <h3 className="text-2xl font-bold mb-4 text-[#98BAD2] pl-4">{title}</h3>
+    <h3 className="text-2xl font-bold mb-4 text-blue-700 dark:text-[#98BAD2] pl-4">{title}</h3>
     <ul className="space-y-4 pl-4">
       {Object.entries(data).map(([year, items]) => (
         <li key={year}>
@@ -139,8 +139,7 @@ const About: React.FC = () => {
           <img
             src="/About_profile.jpg"
             alt="Profile"
-            className="w-36 h-36 sm:w-40 sm:h-40 md:w-48 md:h-48 lg:w-56 lg:h-56 xl:w-64 xl:h-64 border-8 border rounded-full shadow-lg"
-            style={{ borderColor: '#222229' }}
+            className="w-36 h-36 sm:w-40 sm:h-40 md:w-48 md:h-48 lg:w-56 lg:h-56 xl:w-64 xl:h-64 border-8 border-gray-200 dark:border-[#222229] rounded-full shadow-lg"
           />
         </motion.div>
 
@@ -202,7 +201,7 @@ const About: React.FC = () => {
             {certifications.map((cert, idx) => (
               <div
                 key={idx}
-                className="bg-[#2c2f3a] px-4 py-2 rounded-xl text-white text-sm shadow border border-[#98BAD2] hover:scale-105 transition-transform duration-200"
+                className="bg-gray-200 dark:bg-[#2c2f3a] px-4 py-2 rounded-xl text-black dark:text-white text-sm shadow border border-[#98BAD2] hover:scale-105 transition-transform duration-200"
               >
                 {cert.name}
               </div>

--- a/src/app/Project/page.tsx
+++ b/src/app/Project/page.tsx
@@ -104,7 +104,7 @@ const Project: React.FC = () => {
                   e.stopPropagation();
                   setZoomedRepoId(isZoomed ? null : repo.id);
                 }}
-                className={`bg-[#1f1f28] rounded-xl overflow-auto border border-gray-700 shadow-md transition-all duration-300 ease-in-out 
+                className={`bg-white dark:bg-[#1f1f28] rounded-xl overflow-auto border border-gray-700 shadow-md transition-all duration-300 ease-in-out
                 ${isZoomed
                   ? 'fixed top-1/2 left-1/2 z-50 transform -translate-x-1/2 -translate-y-1/2 scale-100 w-[70%] h-[80%] max-w-4xl'
                   : 'relative w-full h-[420px]'} flex flex-col cursor-pointer`}

--- a/src/app/RootShell.tsx
+++ b/src/app/RootShell.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import type React from "react";
 import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBars, faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
 
@@ -47,7 +48,7 @@ export default function RootShell({ children }: { children: React.ReactNode }) {
     <div
       className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen bg-background text-foreground`}
     >
-      <header className="w-full max-w-4xl mx-auto p-4 flex justify-between items-center text-[#98BAD2] font-bold text-xl relative">
+      <header className="w-full max-w-4xl mx-auto p-4 flex justify-between items-center text-blue-700 dark:text-[#98BAD2] font-bold text-xl relative">
         <Link href="/" className="text-2xl font-bold hover:underline">
           nekocat.cc
         </Link>
@@ -64,24 +65,26 @@ export default function RootShell({ children }: { children: React.ReactNode }) {
               {item.label}
             </Link>
           ))}
-          <button
+          <motion.button
+            whileTap={{ rotate: 90 }}
             onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
             className="ml-4 text-xl"
             aria-label="Toggle Theme"
           >
             <FontAwesomeIcon icon={theme === 'dark' ? faSun : faMoon} />
-          </button>
+          </motion.button>
         </nav>
 
         {/* Mobile Hamburger */}
         <div className="md:hidden flex items-center gap-4">
-          <button
+          <motion.button
+            whileTap={{ rotate: 90 }}
             onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
             className="text-xl"
             aria-label="Toggle Theme"
           >
             <FontAwesomeIcon icon={theme === 'dark' ? faSun : faMoon} />
-          </button>
+          </motion.button>
           <button
             onClick={() => setMenuOpen(!menuOpen)}
             className="focus:outline-none text-2xl"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -143,7 +143,7 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground transition-colors duration-500 ease-in-out;
     color: rgb(var(--foreground-rgb));
     background: var(--background);
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,8 +104,7 @@ const Home: React.FC = () => {
           <img
             src="/profile.jpg"
             alt="Profile"
-            className="w-36 h-36 sm:w-40 sm:h-40 md:w-48 md:h-48 lg:w-56 lg:h-56 xl:w-64 xl:h-64 border-8 border rounded-full shadow-lg"
-            style={{ borderColor: '#222229' }}
+            className="w-36 h-36 sm:w-40 sm:h-40 md:w-48 md:h-48 lg:w-56 lg:h-56 xl:w-64 xl:h-64 border-8 border-gray-200 dark:border-[#222229] rounded-full shadow-lg"
           />
         </motion.div>
 
@@ -124,7 +123,7 @@ const Home: React.FC = () => {
           </motion.h2>
 
           <motion.h1
-            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-[#98BAD2] mb-4 font-mono tracking-wider"
+            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-blue-700 dark:text-[#98BAD2] mb-4 font-mono tracking-wider"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 1, duration: 0.3 }}
@@ -139,10 +138,10 @@ const Home: React.FC = () => {
                 {char}
               </motion.span>
             ))}
-            <span className="animate-pulse text-[#BABABA]">|</span>
+            <span className="animate-pulse text-gray-600 dark:text-[#BABABA]">|</span>
           </motion.h1>
 
-          <p className="text-sm sm:text-base md:text-lg text-[#BABABA] leading-relaxed max-w-2xl">
+          <p className="text-sm sm:text-base md:text-lg text-gray-600 dark:text-[#BABABA] leading-relaxed max-w-2xl">
             A student from <span className="text-green-400">NYUST</span> who loves{' '}
             <span className="text-pink-400">AI</span> and{' '}
             <span className="text-yellow-400">programming</span>.<br />
@@ -153,19 +152,19 @@ const Home: React.FC = () => {
 
           <div className="w-full mt-10 flex justify-center lg:justify-start">
             <div className="flex gap-8 text-4xl">
-              <a href="https://blog.nekocat.cc" className="transition-transform duration-200 hover:scale-125 text-[#BABABA] hover:text-black dark:hover:text-white">
+              <a href="https://blog.nekocat.cc" className="transition-transform duration-200 hover:scale-125 text-gray-600 dark:text-[#BABABA] hover:text-black dark:hover:text-white">
                 <FontAwesomeIcon icon={faBookOpen} />
               </a>
-              <a href="https://www.facebook.com/neko.cat.863674/" target="_blank" rel="noopener noreferrer" className="transition-transform duration-200 hover:scale-125 text-[#BABABA] hover:text-blue-400">
+              <a href="https://www.facebook.com/neko.cat.863674/" target="_blank" rel="noopener noreferrer" className="transition-transform duration-200 hover:scale-125 text-gray-600 dark:text-[#BABABA] hover:text-blue-400">
                 <FontAwesomeIcon icon={faFacebook} />
               </a>
-              <a href="https://www.instagram.com/neko._cat422/" target="_blank" rel="noopener noreferrer" className="transition-transform duration-200 hover:scale-125 text-[#BABABA] hover:text-pink-400">
+              <a href="https://www.instagram.com/neko._cat422/" target="_blank" rel="noopener noreferrer" className="transition-transform duration-200 hover:scale-125 text-gray-600 dark:text-[#BABABA] hover:text-pink-400">
                 <FontAwesomeIcon icon={faInstagram} />
               </a>
-              <a href="https://github.com/Catneko-0422" target="_blank" rel="noopener noreferrer" className="transition-transform duration-200 hover:scale-125 text-[#BABABA] hover:text-black dark:hover:text-white">
+              <a href="https://github.com/Catneko-0422" target="_blank" rel="noopener noreferrer" className="transition-transform duration-200 hover:scale-125 text-gray-600 dark:text-[#BABABA] hover:text-black dark:hover:text-white">
                 <FontAwesomeIcon icon={faGithub} />
               </a>
-              <a href="mailto:linyian0422@gmail.com" className="transition-transform duration-200 hover:scale-125 text-[#BABABA] hover:text-green-400">
+              <a href="mailto:linyian0422@gmail.com" className="transition-transform duration-200 hover:scale-125 text-gray-600 dark:text-[#BABABA] hover:text-green-400">
                 <FontAwesomeIcon icon={faEnvelope} />
               </a>
             </div>


### PR DESCRIPTION
## Summary
- add smooth color transitions on theme change
- rotate theme toggle icon on tap
- make header and cards adapt to light mode
- tweak home and about page colors for light mode
- adjust project cards for light mode support

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7f37735c832b9324c32d427e5934