### PR TITLE
Fix project card colors in light theme

### DIFF
--- a/src/app/Project/page.tsx
+++ b/src/app/Project/page.tsx
@@ -104,7 +104,7 @@ const Project: React.FC = () => {
                   e.stopPropagation();
                   setZoomedRepoId(isZoomed ? null : repo.id);
                 }}
-                className={`bg-white dark:bg-[#1f1f28] rounded-xl overflow-auto border border-gray-700 shadow-md transition-all duration-300 ease-in-out
+                className={`bg-[#1f1f28] text-white rounded-xl overflow-auto border border-gray-700 shadow-md transition-all duration-300 ease-in-out
                 ${isZoomed
                   ? 'fixed top-1/2 left-1/2 z-50 transform -translate-x-1/2 -translate-y-1/2 scale-100 w-[70%] h-[80%] max-w-4xl'
                   : 'relative w-full h-[420px]'} flex flex-col cursor-pointer`}
@@ -127,10 +127,10 @@ const Project: React.FC = () => {
 
                 <div className="p-4 flex flex-col justify-between flex-grow">
                   <div>
-                    <h2 className="text-lg font-bold text-foreground mb-1 text-left ml-[10%]">
+                    <h2 className="text-lg font-bold text-white mb-1 text-left ml-[10%]">
                       {repo.name}
                     </h2>
-                    <p className="text-sm text-gray-400 line-clamp-2 mb-2 text-left ml-[10%]">
+                    <p className="text-sm text-gray-300 line-clamp-2 mb-2 text-left ml-[10%]">
                       {repo.description || 'No description provided.'}
                     </p>
                   </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,7 +65,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: #f5f5f5;
   --foreground: oklch(0.13 0.028 261.692);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.13 0.028 261.692);
@@ -97,8 +97,8 @@
   --sidebar-border: oklch(0.928 0.006 264.531);
   --sidebar-ring: oklch(0.707 0.022 261.325);
   --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+  --background-start-rgb: 235, 236, 240;
+  --background-end-rgb: 245, 245, 245;
 }
 
 .dark {


### PR DESCRIPTION
## Summary
- make project cards use dark backgrounds with white text
- soften light theme background

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f815576f4832b812f5a19e76a2211